### PR TITLE
Fixes for elixir 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+all:
+	mix deps.clean --all
+	mix deps.get
+	mix compile
+	mix escript.build
+	./example_elixir_parser example/input.txt

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ yecc. Leex and yecc are lex/yacc of erlang in the
 
 ## Helpful links
 
-The canonical documentation for leex and yecc 
+The canonical documentation for leex and yecc
 
  * http://erlang.org/doc/man/leex.html
  * http://erlang.org/doc/man/yecc.html
@@ -71,7 +71,7 @@ part of the build.
    INT        = [0-9]+
    NAME       = :[a-zA-Z_][a-zA-Z0-9_]*
    WHITESPACE = [\s\t\n\r]
-   
+
    Rules.
    \+            : {token, {'+',  TokenLine}}.
    \-            : {token, {'-',  TokenLine}}.
@@ -134,10 +134,10 @@ Define a yacc style grammer in `src/example_elixir_parser.yrl`
 
    Erlang code.
 
-   unwrap({int, Line, Value}) -> {int, Line, list_to_integer(Value)}.   
+   unwrap({int, Line, Value}) -> {int, Line, list_to_integer(Value)}.
    ```
 
-Given the above example of 
+Given the above example of
 
    ```
    :a = 7
@@ -175,8 +175,11 @@ To mix.exs, add
      [app: :my_parser,
        ...
        escript: [main_module: ExampleElixirParser.Main],
+       compilers: [:yecc, :leex] ++ Mix.compilers(),
      ]
    ```
+
+*NOTE: the `compilers:` is new since elixir 1.3*
 
 This is what `mix` uses to know what to use as the main entry for `mix
 escript.build` generated
@@ -219,7 +222,7 @@ In `lib/example_elixir_parser.ex`, you can write your tree parser in `ExampleEli
         text = File.read!(filename)
         {:ok, tokens, line} = :example_elixir_parser_lexer.string(String.to_char_list(text))
         {:ok, tree} = :example_elixir_parser.parse(tokens)
-        process_tree(tree)        
+        process_tree(tree)
       end
    end
    ```
@@ -264,7 +267,7 @@ which will yield
    %{a: 7, b: 4, result: 27.0}
    ```
 
-### Extra 
+### Extra
 
 You can get a graph of the lexer by calling `:leex:file` with the `:dfa_graph` option.
 

--- a/lib/example_elixir_parser.ex
+++ b/lib/example_elixir_parser.ex
@@ -22,7 +22,7 @@ defmodule ExampleElixirParser do
   defp reduce_to_value({:atom, _line, atom}, state) do
     state[atom]
   end
-  
+
   defp evaluate_tree([{:assign, {:atom, _line, lhs}, rhs} | tail], state) do
     rhs_value = reduce_to_value(rhs, state)
     evaluate_tree(tail, Map.merge(state, %{lhs => rhs_value}))
@@ -37,7 +37,7 @@ defmodule ExampleElixirParser do
   end
 
   def parse_and_eval(string) do
-    {:ok, tokens, _line} = :example_elixir_parser_lexer.string(String.to_char_list(string))
+    {:ok, tokens, _line} = :example_elixir_parser_lexer.string(String.to_charlist(string))
     {:ok, tree} = :example_elixir_parser.parse(tokens)
     process_tree(tree)
   end

--- a/lib/main.ex
+++ b/lib/main.ex
@@ -11,8 +11,14 @@ defmodule ExampleElixirParser.Main do
     IO.puts "\nFinal state"
     IO.inspect state, pretty: true
   end
-  
+
+  def main([]) do
+    IO.puts "Usage ./example_elixir_parser <filename>"
+  end
+
   def main(args) do
+    IO.puts "derp"
+    IO.puts "#{args}"
     filename = Enum.fetch!(args, 0)
 
     IO.puts "Parsing #{filename}"

--- a/mix.exs
+++ b/mix.exs
@@ -4,11 +4,13 @@ defmodule ExampleElixirParser.Mixfile do
   def project do
     [app: :example_elixir_parser,
      version: "0.1.0",
-     elixir: "~> 1.3",
+     elixir: "~> 1.19",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      escript: [main_module: ExampleElixirParser.Main],
-     deps: deps()]
+     deps: deps(),
+     compilers: [:yecc, :leex] ++ Mix.compilers(),
+    ]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
* Add leex and yecc to compilers
* Fix deprecated `to_char_list`
* Check args were given